### PR TITLE
[patch] graceful shutdown skipped

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ type Server struct {
 	// Port represents the server port.
 	Port int `yaml:"port"`
 
-	// EnableDebug represents if user want to enable debug funcationality.
+	// EnableDebug represents if user want to enable debug functionality.
 	EnableDebug bool `yaml:"enable_debug"`
 
 	// DebugPort represents debug server port.
@@ -133,7 +133,7 @@ type Authorization struct {
 	// PubKeyRefreshDuration represents the refresh duration of Athenz PubKey.
 	PubKeyRefreshDuration string `yaml:"pubKeyRefreshDuration"`
 
-	// PubKeySysAuthDomain represents the system authenicate domain of Athenz.
+	// PubKeySysAuthDomain represents the system authentication domain of Athenz.
 	PubKeySysAuthDomain string `yaml:"pubKeySysAuthDomain"`
 
 	// PubKeyEtagExpTime represents the Etag cache expiration time of Athenz PubKey.

--- a/config/config.go
+++ b/config/config.go
@@ -142,6 +142,9 @@ type Authorization struct {
 	// PubKeyEtagFlushDur represent the Etag cache expiration check duration.
 	PubKeyEtagFlushDur string `yaml:"pubKeyEtagFlushDur"`
 
+	// PubKeyErrRetryInterval represent the retry interval when fail to get the pubkey from Athenz server.
+	PubKeyErrRetryInterval string `yaml:"pubKeyErrRetryInterval"`
+
 	// AthenzDomains represents the Athenz domains to fetch the policy.
 	AthenzDomains []string `yaml:"athenzDomains"`
 
@@ -156,6 +159,9 @@ type Authorization struct {
 
 	// PolicyEtagFlushDur represent the Etag cache expiration check duration.
 	PolicyEtagFlushDur string `yaml:"policyEtagFlushDur"`
+
+	// PolicyErrRetryInterval represent the retry interval when fail to get the policies from Athenz server.
+	PolicyErrRetryInterval string `yaml:"policyErrRetryInterval"`
 }
 
 // New returns the decoded configuration YAML file as *Config struct. Returns non-nil error if any.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -85,8 +85,8 @@ func TestNew(t *testing.T) {
 					HealthzPort:      6082,
 					HealthzPath:      "/healthz",
 					Timeout:          "10s",
-					ShutdownDuration: "5s",
-					ProbeWaitTime:    "3s",
+					ShutdownDuration: "10s",
+					ProbeWaitTime:    "7s",
 					TLS: TLS{
 						Enabled: false,
 						Cert:    "/etc/athenz/provider/keys/server.crt",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -86,7 +86,7 @@ func TestNew(t *testing.T) {
 					HealthzPath:      "/healthz",
 					Timeout:          "10s",
 					ShutdownDuration: "10s",
-					ProbeWaitTime:    "7s",
+					ProbeWaitTime:    "9s",
 					TLS: TLS{
 						Enabled: false,
 						Cert:    "/etc/athenz/provider/keys/server.crt",

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -7,8 +7,8 @@ server:
   health_check_port: 6082
   health_check_path: /healthz
   timeout: 10s
-  shutdown_duration: 5s
-  probe_wait_time: 3s
+  shutdown_duration: 10s
+  probe_wait_time: 7s
   tls:
     enabled: false
     cert: /etc/athenz/provider/keys/server.crt

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -8,7 +8,7 @@ server:
   health_check_path: /healthz
   timeout: 10s
   shutdown_duration: 10s
-  probe_wait_time: 7s
+  probe_wait_time: 9s
   tls:
     enabled: false
     cert: /etc/athenz/provider/keys/server.crt

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -73,7 +73,6 @@ func handleError(rw http.ResponseWriter, r *http.Request, err error) {
 	if !strings.Contains(err.Error(), ErrMsgVerifyRoleToken) {
 		glg.Debug("handleError: " + err.Error())
 		status = http.StatusBadGateway
-		// rw.Write([]byte(err.Error()))
 	}
 	// request context canceled
 	if errors.Cause(err) == context.Canceled {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -71,7 +71,9 @@ func handleError(rw http.ResponseWriter, r *http.Request, err error) {
 	}
 	status := http.StatusUnauthorized
 	if !strings.Contains(err.Error(), ErrMsgVerifyRoleToken) {
+		glg.Debug("handleError: " + err.Error())
 		status = http.StatusBadGateway
+		// rw.Write([]byte(err.Error()))
 	}
 	// request context canceled
 	if errors.Cause(err) == context.Canceled {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -48,7 +48,7 @@ func TestNew(t *testing.T) {
 						}(),
 					},
 					bp: infra.NewBuffer(64),
-					prov: &service.AuthorizedMock{
+					prov: &service.AuthorizerdMock{
 						VerifyRoleTokenFunc: func(ctx context.Context, tok, act, res string) error {
 							return nil
 						},
@@ -86,7 +86,7 @@ func TestNew(t *testing.T) {
 						}(),
 					},
 					bp: infra.NewBuffer(64),
-					prov: &service.AuthorizedMock{
+					prov: &service.AuthorizerdMock{
 						VerifyRoleTokenFunc: func(ctx context.Context, tok, act, res string) error {
 							return errors.New("deny")
 						},
@@ -122,7 +122,7 @@ func TestNew(t *testing.T) {
 						Scheme: "http",
 					},
 					bp: infra.NewBuffer(64),
-					prov: &service.AuthorizedMock{
+					prov: &service.AuthorizerdMock{
 						VerifyRoleTokenFunc: func(ctx context.Context, tok, act, res string) error {
 							return nil
 						},
@@ -151,7 +151,7 @@ func TestNew(t *testing.T) {
 						Port: 9999,
 					},
 					bp: infra.NewBuffer(64),
-					prov: &service.AuthorizedMock{
+					prov: &service.AuthorizerdMock{
 						VerifyRoleTokenFunc: func(ctx context.Context, tok, act, res string) error {
 							return nil
 						},
@@ -186,7 +186,7 @@ func TestNew(t *testing.T) {
 						}(),
 					},
 					bp: infra.NewBuffer(64),
-					prov: &service.AuthorizedMock{
+					prov: &service.AuthorizerdMock{
 						VerifyRoleTokenFunc: func(ctx context.Context, tok, act, res string) error {
 							return context.Canceled
 						},

--- a/handler/transport_test.go
+++ b/handler/transport_test.go
@@ -31,7 +31,7 @@ func Test_transport_RoundTrip(t *testing.T) {
 			name: "verify role token failed",
 			fields: fields{
 				RoundTripper: nil,
-				prov: &service.AuthorizedMock{
+				prov: &service.AuthorizerdMock{
 					VerifyRoleTokenFunc: func(ctx context.Context, tok, act, res string) error {
 						return errors.New("dummy error")
 					},
@@ -58,7 +58,7 @@ func Test_transport_RoundTrip(t *testing.T) {
 						}, nil
 					},
 				},
-				prov: &service.AuthorizedMock{
+				prov: &service.AuthorizerdMock{
 					VerifyRoleTokenFunc: func(ctx context.Context, tok, act, res string) error {
 						return nil
 					},

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func run(cfg config.Config) []error {
 		select {
 		case <-sigCh:
 			cancel()
-			glg.Warn("authorization-proxy server shutdown...")
+			glg.Warn("Got authorization-proxy server shutdown signal...")
 		case errs := <-ech:
 			return errs
 		}

--- a/service/authorizerd_mock.go
+++ b/service/authorizerd_mock.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 )
 
-type AuthorizedMock struct {
+type AuthorizerdMock struct {
 	StartFunc           func(context.Context) <-chan error
 	VerifyRoleTokenFunc func(ctx context.Context, tok, act, res string) error
 	VerifyRoleJWTFunc   func(ctx context.Context, tok, act, res string) error
@@ -13,22 +13,22 @@ type AuthorizedMock struct {
 	GetPolicyCacheFunc  func(ctx context.Context) map[string]interface{}
 }
 
-func (am *AuthorizedMock) Start(ctx context.Context) <-chan error {
+func (am *AuthorizerdMock) Start(ctx context.Context) <-chan error {
 	return am.StartFunc(ctx)
 }
 
-func (am *AuthorizedMock) VerifyRoleToken(ctx context.Context, tok, act, res string) error {
+func (am *AuthorizerdMock) VerifyRoleToken(ctx context.Context, tok, act, res string) error {
 	return am.VerifyRoleTokenFunc(ctx, tok, act, res)
 }
 
-func (am *AuthorizedMock) VerifyRoleJWT(ctx context.Context, tok, act, res string) error {
+func (am *AuthorizerdMock) VerifyRoleJWT(ctx context.Context, tok, act, res string) error {
 	return am.VerifyRoleJWTFunc(ctx, tok, act, res)
 }
 
-func (am *AuthorizedMock) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certificate, act, res string) error {
+func (am *AuthorizerdMock) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certificate, act, res string) error {
 	return am.VerifyRoleCertFunc(ctx, peerCerts, act, res)
 }
 
-func (am *AuthorizedMock) GetPolicyCache(ctx context.Context) map[string]interface{} {
+func (am *AuthorizerdMock) GetPolicyCache(ctx context.Context) map[string]interface{} {
 	return am.GetPolicyCacheFunc(ctx)
 }

--- a/service/server.go
+++ b/service/server.go
@@ -137,8 +137,8 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 	)
 
 	wg := new(sync.WaitGroup)
-	wg.Add(2)
 
+	wg.Add(1)
 	go func() {
 		s.mu.Lock()
 		s.srvRunning = true
@@ -147,6 +147,7 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 
 		glg.Info("authorization proxy api server starting")
 		sech <- s.listenAndServeAPI()
+		glg.Info("authorization proxy api server closed")
 		close(sech)
 
 		s.mu.Lock()
@@ -154,6 +155,7 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 		s.mu.Unlock()
 	}()
 
+	wg.Add(1)
 	go func() {
 		s.mu.Lock()
 		s.hcRunning = true
@@ -162,6 +164,7 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 
 		glg.Info("authorization proxy health check server starting")
 		hech <- s.hcsrv.ListenAndServe()
+		glg.Info("authorization proxy health check server closed")
 		close(hech)
 
 		s.mu.Lock()
@@ -172,7 +175,7 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 	if s.cfg.EnableDebug {
 		wg.Add(1)
 		dech = make(chan error, 1)
-	
+
 		go func() {
 			s.mu.Lock()
 			s.dRunning = true
@@ -181,6 +184,7 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 
 			glg.Info("authorization proxy debug server starting")
 			dech <- s.dsrv.ListenAndServe()
+			glg.Info("authorization proxy debug server closed")
 			close(dech)
 
 			s.mu.Lock()

--- a/service/server.go
+++ b/service/server.go
@@ -135,12 +135,9 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 		hech = make(chan error, 1)
 		dech chan error
 	)
-	if s.cfg.EnableDebug {
-		dech = make(chan error, 1)
-	}
 
 	wg := new(sync.WaitGroup)
-	wg.Add(3)
+	wg.Add(2)
 
 	go func() {
 		s.mu.Lock()
@@ -173,6 +170,9 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 	}()
 
 	if s.cfg.EnableDebug {
+		wg.Add(1)
+		dech = make(chan error, 1)
+	
 		go func() {
 			s.mu.Lock()
 			s.dRunning = true
@@ -187,8 +187,6 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 			s.dRunning = false
 			s.mu.Unlock()
 		}()
-	} else {
-		wg.Done()
 	}
 
 	go func() {

--- a/service/server.go
+++ b/service/server.go
@@ -112,12 +112,12 @@ func NewServer(opts ...Option) Server {
 
 	s.sddur, err = time.ParseDuration(s.cfg.ShutdownDuration)
 	if err != nil {
-		s.sddur = time.Second * 5
+		s.sddur = time.Second * 10
 	}
 
 	s.pwt, err = time.ParseDuration(s.cfg.ProbeWaitTime)
 	if err != nil {
-		s.pwt = time.Second * 3
+		s.pwt = time.Second * 7
 	}
 
 	return s

--- a/service/server.go
+++ b/service/server.go
@@ -208,15 +208,15 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 
 		shutdownSrvs := func(errs []error) {
 			if s.hcRunning {
-				glg.Info("authorization proxy health check server will shutdown")
+				glg.Info("authorization proxy health check server will shutdown...")
 				errs = appendErr(errs, s.hcShutdown(context.Background()))
 			}
 			if s.srvRunning {
-				glg.Info("authorization proxy api server will shutdown")
+				glg.Info("authorization proxy api server will shutdown...")
 				errs = appendErr(errs, s.apiShutdown(context.Background()))
 			}
 			if s.dRunning {
-				glg.Info("authorization proxy debug server will shutdown")
+				glg.Info("authorization proxy debug server will shutdown...")
 				errs = appendErr(errs, s.dShutdown(context.Background()))
 			}
 			glg.Info("authorization proxy has already shut down gracefully")

--- a/service/server.go
+++ b/service/server.go
@@ -117,7 +117,7 @@ func NewServer(opts ...Option) Server {
 
 	s.pwt, err = time.ParseDuration(s.cfg.ProbeWaitTime)
 	if err != nil {
-		s.pwt = time.Second * 7
+		s.pwt = time.Second * 9
 	}
 
 	return s

--- a/service/server.go
+++ b/service/server.go
@@ -187,6 +187,8 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 			s.dRunning = false
 			s.mu.Unlock()
 		}()
+	} else {
+		wg.Done()
 	}
 
 	go func() {

--- a/service/server.go
+++ b/service/server.go
@@ -192,6 +192,8 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 	}
 
 	go func() {
+		defer close(echan)
+
 		// wait for all server running
 		wg.Wait()
 
@@ -215,6 +217,7 @@ func (s *server) ListenAndServe(ctx context.Context) <-chan []error {
 				glg.Info("authorization proxy debug server will shutdown")
 				errs = appendErr(errs, s.dShutdown(context.Background()))
 			}
+			glg.Info("authorization proxy has already shut down gracefully")
 		}
 
 		errs := make([]error, 0, 3)

--- a/service/server_test.go
+++ b/service/server_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -121,7 +120,6 @@ func Test_server_ListenAndServe(t *testing.T) {
 		hcsrv *http.Server
 		dsrv  *http.Server
 		cfg   config.Server
-		mu    sync.RWMutex
 	}
 	type args struct {
 		ctx        context.Context
@@ -206,7 +204,6 @@ func Test_server_ListenAndServe(t *testing.T) {
 							Key:     keyKey,
 						},
 					},
-					mu: sync.RWMutex{},
 				},
 				args: args{
 					ctx: ctx,
@@ -316,7 +313,6 @@ func Test_server_ListenAndServe(t *testing.T) {
 							Key:     key,
 						},
 					},
-					mu: sync.RWMutex{},
 				},
 				args: args{
 					ctx: context.Background(),
@@ -408,7 +404,6 @@ func Test_server_ListenAndServe(t *testing.T) {
 							Key:     key,
 						},
 					},
-					mu: sync.RWMutex{},
 				},
 				args: args{
 					ctx: context.Background(),
@@ -460,7 +455,6 @@ func Test_server_ListenAndServe(t *testing.T) {
 				hcsrv: tt.fields.hcsrv,
 				dsrv:  tt.fields.dsrv,
 				cfg:   tt.fields.cfg,
-				mu:    tt.fields.mu,
 			}
 
 			e := s.ListenAndServe(tt.args.ctx)
@@ -480,7 +474,6 @@ func Test_server_hcShutdown(t *testing.T) {
 		cfg        config.Server
 		pwt        time.Duration
 		sddur      time.Duration
-		mu         sync.RWMutex
 	}
 	type args struct {
 		ctx context.Context
@@ -536,7 +529,6 @@ func Test_server_hcShutdown(t *testing.T) {
 				cfg:        tt.fields.cfg,
 				pwt:        tt.fields.pwt,
 				sddur:      tt.fields.sddur,
-				mu:         tt.fields.mu,
 			}
 			e := s.hcShutdown(tt.args.ctx)
 			if err := tt.checkFunc(s, e, tt.want); err != nil {
@@ -555,7 +547,6 @@ func Test_server_apiShutdown(t *testing.T) {
 		cfg        config.Server
 		pwt        time.Duration
 		sddur      time.Duration
-		mu         sync.RWMutex
 	}
 	type args struct {
 		ctx context.Context
@@ -611,7 +602,6 @@ func Test_server_apiShutdown(t *testing.T) {
 				cfg:        tt.fields.cfg,
 				pwt:        tt.fields.pwt,
 				sddur:      tt.fields.sddur,
-				mu:         tt.fields.mu,
 			}
 			e := s.apiShutdown(tt.args.ctx)
 			if err := tt.checkFunc(s, e, tt.want); err != nil {
@@ -631,7 +621,6 @@ func Test_server_createHealthCheckServiceMux(t *testing.T) {
 		beforeFunc func() error
 		checkFunc  func(*http.ServeMux) error
 		afterFunc  func() error
-		want       http.ServeMux
 		wantErr    error
 	}
 	tests := []test{

--- a/usecase/providerd.go
+++ b/usecase/providerd.go
@@ -79,8 +79,7 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 					errs = append(errs, errors.WithMessagef(err, "%d times appeared", count))
 				}
 				errs = append(errs, ctx.Err())
-				ech <- errs
-				return
+				// ctx.Done() will be handled by sch
 			case e := <-pch:
 				glg.Errorf("pch %v", e)
 				glg.Error(e)

--- a/usecase/providerd.go
+++ b/usecase/providerd.go
@@ -80,8 +80,8 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 					// prevent handling nil value on channel close
 					continue
 				}
-				// count errors by cause
 				glg.Errorf("pch %v", e)
+				// count errors by cause
 				cause := errors.Cause(e)
 				_, ok := emap[cause]
 				if !ok {
@@ -95,7 +95,6 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 					continue
 				}
 				glg.Errorf("sch %v", serrs)
-
 				// aggregate all errors as array
 				errs := make([]error, 0, len(emap))
 				for err, count := range emap {

--- a/usecase/providerd.go
+++ b/usecase/providerd.go
@@ -76,10 +76,6 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 			// ctx.Done() will be handled by sch
 			// case <-ctx.Done():
 			case e := <-pch:
-				if e == nil {
-					// prevent handling nil value on channel close
-					continue
-				}
 				glg.Errorf("pch %v", e)
 				// count errors by cause
 				cause := errors.Cause(e)
@@ -90,10 +86,6 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 					emap[cause]++
 				}
 			case serrs := <-sch:
-				if serrs == nil {
-					// prevent handling nil value on channel close
-					continue
-				}
 				glg.Errorf("sch %v", serrs)
 				// aggregate all errors as array
 				errs := make([]error, 0, len(emap))
@@ -114,15 +106,20 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 func newAuthorizationd(cfg config.Config) (service.Authorizationd, error) {
 	return providerd.New(
 		providerd.WithAthenzURL(cfg.Athenz.URL),
+
 		providerd.WithPubkeyRefreshDuration(cfg.Authorization.PubKeyRefreshDuration),
 		providerd.WithPubkeySysAuthDomain(cfg.Authorization.PubKeySysAuthDomain),
 		providerd.WithPubkeyEtagExpTime(cfg.Authorization.PubKeyEtagExpTime),
 		providerd.WithPubkeyEtagFlushDuration(cfg.Authorization.PubKeyEtagFlushDur),
+		providerd.WithPubkeyErrRetryInterval(cfg.Authorization.PubKeyErrRetryInterval),
 		providerd.WithAthenzDomains(cfg.Authorization.AthenzDomains...),
+
 		providerd.WithPolicyExpireMargin(cfg.Authorization.PolicyExpireMargin),
 		providerd.WithPolicyRefreshDuration(cfg.Authorization.PolicyRefreshDuration),
 		providerd.WithPolicyEtagFlushDuration(cfg.Authorization.PolicyEtagFlushDur),
 		providerd.WithPolicyEtagExpTime(cfg.Authorization.PolicyEtagExpTime),
+		providerd.WithPolicyErrRetryInterval(cfg.Authorization.PolicyErrRetryInterval),
+
 		providerd.WithDisableJwkd(),
 	)
 }

--- a/usecase/providerd.go
+++ b/usecase/providerd.go
@@ -75,7 +75,12 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 			select {
 			// ctx.Done() will be handled by sch
 			// case <-ctx.Done():
-			case e := <-pch:
+			case e, chOk := <-pch:
+				if !chOk {
+					// prevent handling nil value on channel close
+					pch = nil
+					continue
+				}
 				glg.Errorf("pch %v", e)
 				// count errors by cause
 				cause := errors.Cause(e)
@@ -85,7 +90,12 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 				} else {
 					emap[cause]++
 				}
-			case serrs := <-sch:
+			case serrs, chOk := <-sch:
+				if !chOk {
+					// prevent handling nil value on channel close
+					sch = nil
+					continue
+				}
 				glg.Errorf("sch %v", serrs)
 				// aggregate all errors as array
 				errs := make([]error, 0, len(emap))

--- a/usecase/providerd.go
+++ b/usecase/providerd.go
@@ -76,8 +76,7 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 			// ctx.Done() will be handled by sch
 			// case <-ctx.Done():
 			case e, ok := <-pch:
-				if !ok {
-					// prevent handling nil value on channel close
+				if !ok { // handle channel close
 					pch = nil
 					continue
 				}
@@ -91,8 +90,7 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 					emap[cause]++
 				}
 			case serrs, ok := <-sch:
-				if !ok {
-					// prevent handling nil value on channel close
+				if !ok { // handle channel close
 					sch = nil
 					continue
 				}

--- a/usecase/providerd.go
+++ b/usecase/providerd.go
@@ -99,7 +99,7 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 				// aggregate all errors as array
 				errs := make([]error, 0, len(emap))
 				for err, count := range emap {
-					errs = append(errs, errors.WithMessagef(err, "%d times appeared", count))
+					errs = append(errs, errors.WithMessagef(err, "providerd: %d times appeared", count))
 				}
 
 				// return all errors

--- a/usecase/providerd.go
+++ b/usecase/providerd.go
@@ -75,8 +75,8 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 			select {
 			// ctx.Done() will be handled by sch
 			// case <-ctx.Done():
-			case e, chOk := <-pch:
-				if !chOk {
+			case e, ok := <-pch:
+				if !ok {
 					// prevent handling nil value on channel close
 					pch = nil
 					continue
@@ -84,14 +84,14 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 				glg.Errorf("pch %v", e)
 				// count errors by cause
 				cause := errors.Cause(e)
-				_, ok := emap[cause]
+				_, ok = emap[cause]
 				if !ok {
 					emap[cause] = 1
 				} else {
 					emap[cause]++
 				}
-			case serrs, chOk := <-sch:
-				if !chOk {
+			case serrs, ok := <-sch:
+				if !ok {
 					// prevent handling nil value on channel close
 					sch = nil
 					continue

--- a/usecase/providerd.go
+++ b/usecase/providerd.go
@@ -68,7 +68,7 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 	pch := g.athenz.Start(ctx)
 	sch := g.server.ListenAndServe(ctx)
 	go func() {
-		emap := make(map[error]uint64, 1)
+		emap := make(map[string]uint64, 1)
 		defer close(ech)
 
 		for {
@@ -82,7 +82,7 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 				}
 				glg.Errorf("pch %v", e)
 				// count errors by cause
-				cause := errors.Cause(e)
+				cause := errors.Cause(e).Error()
 				_, ok = emap[cause]
 				if !ok {
 					emap[cause] = 1
@@ -97,8 +97,8 @@ func (g *providerDaemon) Start(ctx context.Context) <-chan []error {
 				glg.Errorf("sch %v", serrs)
 				// aggregate all errors as array
 				errs := make([]error, 0, len(emap))
-				for err, count := range emap {
-					errs = append(errs, errors.WithMessagef(err, "providerd: %d times appeared", count))
+				for errMsg, count := range emap {
+					errs = append(errs, errors.WithMessagef(errors.New(errMsg), "providerd: %d times appeared", count))
 				}
 
 				// return all errors

--- a/usecase/providerd_test.go
+++ b/usecase/providerd_test.go
@@ -156,7 +156,7 @@ func Test_providerDaemon_Start(t *testing.T) {
 					ctx: ctx,
 				},
 				wantErrs: []error{
-					errors.WithMessage(context.Canceled, "1 times appeared"),
+					errors.WithMessage(context.Canceled, "providerd: 1 times appeared"),
 					context.Canceled,
 				},
 				checkFunc: func(got <-chan []error, wantErrs []error) error {
@@ -306,8 +306,8 @@ func Test_providerDaemon_Start(t *testing.T) {
 					ctx: ctx,
 				},
 				wantErrs: []error{
-					errors.WithMessage(errors.Cause(errors.WithMessage(dummyErr, "provider daemon fails")), "3 times appeared"),
-					errors.WithMessage(context.Canceled, "1 times appeared"),
+					errors.WithMessage(errors.Cause(errors.WithMessage(dummyErr, "provider daemon fails")), "providerd: 3 times appeared"),
+					errors.WithMessage(context.Canceled, "providerd: 1 times appeared"),
 					context.Canceled,
 				},
 				checkFunc: func(got <-chan []error, wantErrs []error) error {

--- a/usecase/providerd_test.go
+++ b/usecase/providerd_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -113,6 +114,11 @@ func Test_providerDaemon_Start(t *testing.T) {
 		wantErrs  []error
 		checkFunc func(<-chan []error, []error) error
 	}
+	getLessErrorFunc := func(errs []error) func(i, j int) bool {
+		return func(i, j int) bool {
+			return errs[i].Error() < errs[j].Error()
+		}
+	}
 	tests := []test{
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -180,7 +186,9 @@ func Test_providerDaemon_Start(t *testing.T) {
 					mux.Lock()
 					defer mux.Unlock()
 
-					// check only send errors once and the errors are expected
+					// check only send errors once and the errors are expected ignoring order
+					sort.Slice(gotErrs[0], getLessErrorFunc(gotErrs[0]))
+					sort.Slice(wantErrs, getLessErrorFunc(wantErrs))
 					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrs[0], wantErrs) {
 						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrs, [][]error{wantErrs})
 					}
@@ -246,7 +254,9 @@ func Test_providerDaemon_Start(t *testing.T) {
 					mux.Lock()
 					defer mux.Unlock()
 
-					// check only send errors once and the errors are expected
+					// check only send errors once and the errors are expected ignoring order
+					sort.Slice(gotErrs[0], getLessErrorFunc(gotErrs[0]))
+					sort.Slice(wantErrs, getLessErrorFunc(wantErrs))
 					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrs[0], wantErrs) {
 						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrs[0], wantErrs)
 					}
@@ -331,7 +341,9 @@ func Test_providerDaemon_Start(t *testing.T) {
 					mux.Lock()
 					defer mux.Unlock()
 
-					// check only send errors once and the errors are expected
+					// check only send errors once and the errors are expected ignoring order
+					sort.Slice(gotErrs[0], getLessErrorFunc(gotErrs[0]))
+					sort.Slice(wantErrs, getLessErrorFunc(wantErrs))
 					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrs[0], wantErrs) {
 						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrs, [][]error{wantErrs})
 					}

--- a/usecase/providerd_test.go
+++ b/usecase/providerd_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sort"
 	"sync"
@@ -189,9 +190,12 @@ func Test_providerDaemon_Start(t *testing.T) {
 					// check only send errors once and the errors are expected ignoring order
 					sort.Slice(gotErrs[0], getLessErrorFunc(gotErrs[0]))
 					sort.Slice(wantErrs, getLessErrorFunc(wantErrs))
-					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrs[0], wantErrs) {
-						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrs, [][]error{wantErrs})
+					gotErrsStr := fmt.Sprintf("%v", gotErrs[0])
+					wantErrsStr := fmt.Sprintf("%v", wantErrs)
+					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrsStr, wantErrsStr) {
+						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrsStr, wantErrsStr)
 					}
+
 					return nil
 				},
 			}
@@ -257,8 +261,10 @@ func Test_providerDaemon_Start(t *testing.T) {
 					// check only send errors once and the errors are expected ignoring order
 					sort.Slice(gotErrs[0], getLessErrorFunc(gotErrs[0]))
 					sort.Slice(wantErrs, getLessErrorFunc(wantErrs))
-					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrs[0], wantErrs) {
-						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrs[0], wantErrs)
+					gotErrsStr := fmt.Sprintf("%v", gotErrs[0])
+					wantErrsStr := fmt.Sprintf("%v", wantErrs)
+					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrsStr, wantErrsStr) {
+						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrsStr, wantErrsStr)
 					}
 
 					cancel()
@@ -344,9 +350,12 @@ func Test_providerDaemon_Start(t *testing.T) {
 					// check only send errors once and the errors are expected ignoring order
 					sort.Slice(gotErrs[0], getLessErrorFunc(gotErrs[0]))
 					sort.Slice(wantErrs, getLessErrorFunc(wantErrs))
-					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrs[0], wantErrs) {
-						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrs, [][]error{wantErrs})
+					gotErrsStr := fmt.Sprintf("%v", gotErrs[0])
+					wantErrsStr := fmt.Sprintf("%v", wantErrs)
+					if len(gotErrs) != 1 || !reflect.DeepEqual(gotErrsStr, wantErrsStr) {
+						return errors.Errorf("Invalid err, got: %v, want: %v", gotErrsStr, wantErrsStr)
 					}
+
 					return nil
 				},
 			}


### PR DESCRIPTION
# issue
1. when debug disable, server shut down not called
    - add wg.done()
2. when context cancel by `sigterm`,  will not wait for data from `sch`, the server may not shutdown gracefully.
https://github.com/yahoojapan/authorization-proxy/blob/master/usecase/providerd.go#L76-L83
    - return only on `sch`