### PR TITLE
[major] Add VerifyClientID

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -181,8 +181,8 @@ type Access struct {
 	// VerifyCertThumbprint represents whether to enforce certificate thumbprint verification.
 	VerifyCertThumbprint bool `yaml:"verify_cert_thumbprint"`
 
-	// VerifyTokenClientID represents whether to enforce certificate common name and client_id verification.
-	VerifyTokenClientID bool `yaml:"verify_token_client_id"`
+	// VerifyClientID represents whether to enforce certificate common name and client_id verification.
+	VerifyClientID bool `yaml:"verify_client_id"`
 
 	// AuthorizedClientIDs represents list of allowed client_id and common name.
 	AuthorizedClientIDs map[string][]string `yaml:"authorized_client_ids"`

--- a/config/config.go
+++ b/config/config.go
@@ -185,7 +185,7 @@ type Access struct {
 	VerifyTokenClientID bool `yaml:"verify_token_client_id"`
 
 	// AuthorizedClientIDs represents list of allowed client_id and common name.
-	AuthorizedClientIDs map[string][]string `yaml:"authorized_principals"`
+	AuthorizedClientIDs map[string][]string `yaml:"authorized_client_ids"`
 
 	// CertBackdateDur represents the certificate issue time backdating duration. (for usecase: new cert + old token)
 	CertBackdateDur string `yaml:"cert_backdate_dur"`

--- a/config/config.go
+++ b/config/config.go
@@ -184,8 +184,8 @@ type Access struct {
 	// VerifyTokenClientID represents whether to enforce certificate common name and client_id verification.
 	VerifyTokenClientID bool `yaml:"verify_token_client_id"`
 
-	// AuthorizedPrincipals represents list of allowed client_id and common name.
-	AuthorizedPrincipals map[string][]string `yaml:"authorized_principals"`
+	// AuthorizedClientIDs represents list of allowed client_id and common name.
+	AuthorizedClientIDs map[string][]string `yaml:"authorized_principals"`
 
 	// CertBackdateDur represents the certificate issue time backdating duration. (for usecase: new cert + old token)
 	CertBackdateDur string `yaml:"cert_backdate_dur"`

--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,7 @@ type Authorization struct {
 	PolicyErrRetryInterval string `yaml:"policyErrRetryInterval"`
 
 	// Access represents the configuration to control access token verification.
-	Access []Access `yaml:"access_tokens"`
+	Access Access `yaml:"access_token"`
 
 	// Role represents the configuration to control role token verification.
 	Role Role `yaml:"roletoken"`
@@ -180,6 +180,12 @@ type Access struct {
 
 	// VerifyCertThumbprint represents whether to enforce certificate thumbprint verification.
 	VerifyCertThumbprint bool `yaml:"verify_cert_thumbprint"`
+
+	// VerifyTokenClientID represents whether to enforce certificate common name and client_id verification.
+	VerifyTokenClientID bool `yaml:"verify_token_client_id"`
+
+	// AuthorizedPrincipals represents list of allowed client_id and common name.
+	AuthorizedPrincipals map[string][]string `yaml:"authorized_principals"`
 
 	// CertBackdateDur represents the certificate issue time backdating duration. (for usecase: new cert + old token)
 	CertBackdateDur string `yaml:"cert_backdate_dur"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -130,7 +130,7 @@ func TestNew(t *testing.T) {
 						Enable:               true,
 						VerifyCertThumbprint: true,
 						VerifyTokenClientID:  true,
-						AuthorizedPrincipals: map[string][]string{
+						AuthorizedClientIDs: map[string][]string{
 							"common_name1": []string{"client_id1", "client_id2"},
 							"common_name2": []string{"client_id1", "client_id2"},
 						},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,7 +129,7 @@ func TestNew(t *testing.T) {
 					Access: Access{
 						Enable:               true,
 						VerifyCertThumbprint: true,
-						VerifyTokenClientID:  false,
+						VerifyClientID:       false,
 						AuthorizedClientIDs: map[string][]string{
 							"common_name1": []string{"client_id1", "client_id2"},
 							"common_name2": []string{"client_id1", "client_id2"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -126,13 +126,16 @@ func TestNew(t *testing.T) {
 					Role: Role{
 						Enable: true,
 					},
-					Access: []Access{
-						Access{
-							Enable:               true,
-							VerifyCertThumbprint: true,
-							CertBackdateDur:      "1h",
-							CertOffsetDur:        "1h",
+					Access: Access{
+						Enable:               true,
+						VerifyCertThumbprint: true,
+						VerifyTokenClientID:  true,
+						AuthorizedPrincipals: map[string][]string{
+							"common_name1": []string{"client_id1", "client_id2"},
+							"common_name2": []string{"client_id1", "client_id2"},
 						},
+						CertBackdateDur: "1h",
+						CertOffsetDur:   "1h",
 					},
 				},
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,7 +129,7 @@ func TestNew(t *testing.T) {
 					Access: Access{
 						Enable:               true,
 						VerifyCertThumbprint: true,
-						VerifyTokenClientID:  true,
+						VerifyTokenClientID:  false,
 						AuthorizedClientIDs: map[string][]string{
 							"common_name1": []string{"client_id1", "client_id2"},
 							"common_name2": []string{"client_id1", "client_id2"},

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -45,7 +45,7 @@ provider:
     enable: true
     verify_cert_thumbprint: true
     verify_token_client_id: true
-    authorized_principals:
+    authorized_client_ids:
       common_name1:
         - client_id1
         - client_id2

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -44,7 +44,7 @@ provider:
   access_token:
     enable: true
     verify_cert_thumbprint: true
-    verify_token_client_id: false
+    verify_client_id: false
     authorized_client_ids:
       common_name1:
         - client_id1

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -41,9 +41,16 @@ provider:
   policyEtagFlushDur: 24h
   roletoken:
       enable: true
-  access_tokens:
-    -
-      enable: true
-      verify_cert_thumbprint: true
-      cert_backdate_dur: 1h
-      cert_offset_dur: 1h
+  access_token:
+    enable: true
+    verify_cert_thumbprint: true
+    verify_token_client_id: true
+    authorized_principals:
+      common_name1:
+        - client_id1
+        - client_id2
+      common_name2:
+        - client_id1
+        - client_id2
+    cert_backdate_dur: 1h
+    cert_offset_dur: 1h

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -44,7 +44,7 @@ provider:
   access_token:
     enable: true
     verify_cert_thumbprint: true
-    verify_token_client_id: true
+    verify_token_client_id: false
     authorized_client_ids:
       common_name1:
         - client_id1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/kpango/glg v1.5.1
 	github.com/pkg/errors v0.9.1
-	github.com/yahoojapan/athenz-authorizer/v2 v2.2.0
+	github.com/yahoojapan/athenz-authorizer/v3 v3.0.0
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yahoo/athenz v1.8.33 h1:SxHH/0Ldvs4T+2D/3wgtKdrgRKzEePTmJerBaTKWpow=
 github.com/yahoo/athenz v1.8.33/go.mod h1:bGC4PzHUQRC2byuyYqnKYofHCsGLPWSNoAWorW+juTc=
-github.com/yahoojapan/athenz-authorizer/v2 v2.2.0 h1:+gEq27LeOwDPHKoa+cJxSlFW2RRWzKQq++ZzuQRvLZY=
-github.com/yahoojapan/athenz-authorizer/v2 v2.2.0/go.mod h1:QQUsAF/vEAou3+zxDiHySsHBbiWIVI1UYmr85sM57L4=
+github.com/yahoojapan/athenz-authorizer/v3 v3.0.0 h1:jSBAJ6eFNnw/lPZWhFpamcqdWCe8cT/t5PXggA5giZY=
+github.com/yahoojapan/athenz-authorizer/v3 v3.0.0/go.mod h1:Rr3A0NMsV6ISCrXiRo/L1vf/anRtj4ygVB86xCtu6JE=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=

--- a/main_test.go
+++ b/main_test.go
@@ -101,11 +101,6 @@ func Test_run(t *testing.T) {
 					cfg: config.Config{
 						Debug:              true,
 						EnableColorLogging: true,
-						Authorization: config.Authorization{
-							Access: config.Access{
-								Enable: true,
-							},
-						},
 					},
 				},
 				checkFunc: func(cfg config.Config) error {
@@ -152,17 +147,9 @@ func Test_run(t *testing.T) {
 						Athenz: config.Athenz{
 							URL: "127.0.0.1",
 						},
-						Authorization: config.Authorization{
-							Access: config.Access{
-								Enable: true,
-							},
-						},
 					},
 				},
 				checkFunc: func(cfg config.Config) error {
-					// daemon init error: failed to fetch remote JWK: Get "https://127.0.0.1/oauth2/keys": dial tcp 127.0.0.1:443: connect: connection refused,
-					// daemon init error: error when processing pubkey: Error updating ZMS athenz pubkey: error fetch public key entries: error make http request: Get "https://127.0.0.1/domain/sys.auth/service/zms": dial tcp 127.0.0.1:443: connect: connection refused
-
 					got := run(cfg)
 					want1 := "daemon init error: error when processing pubkey: Error updating ZMS athenz pubkey: error fetch public key entries: error make http request: Get \"https://127.0.0.1/domain/sys.auth/service/zms\": dial tcp 127.0.0.1:443: connect: connection refused"
 					want2 := "daemon init error: error when processing pubkey: Error updating ZTS athenz pubkey: error fetch public key entries: error make http request: Get \"https://127.0.0.1/domain/sys.auth/service/zts\": dial tcp 127.0.0.1:443: connect: connection refused"

--- a/main_test.go
+++ b/main_test.go
@@ -101,6 +101,11 @@ func Test_run(t *testing.T) {
 					cfg: config.Config{
 						Debug:              true,
 						EnableColorLogging: true,
+						Authorization: config.Authorization{
+							Access: config.Access{
+								Enable: true,
+							},
+						},
 					},
 				},
 				checkFunc: func(cfg config.Config) error {
@@ -147,9 +152,17 @@ func Test_run(t *testing.T) {
 						Athenz: config.Athenz{
 							URL: "127.0.0.1",
 						},
+						Authorization: config.Authorization{
+							Access: config.Access{
+								Enable: true,
+							},
+						},
 					},
 				},
 				checkFunc: func(cfg config.Config) error {
+					// daemon init error: failed to fetch remote JWK: Get "https://127.0.0.1/oauth2/keys": dial tcp 127.0.0.1:443: connect: connection refused,
+					// daemon init error: error when processing pubkey: Error updating ZMS athenz pubkey: error fetch public key entries: error make http request: Get "https://127.0.0.1/domain/sys.auth/service/zms": dial tcp 127.0.0.1:443: connect: connection refused
+
 					got := run(cfg)
 					want1 := "daemon init error: error when processing pubkey: Error updating ZMS athenz pubkey: error fetch public key entries: error make http request: Get \"https://127.0.0.1/domain/sys.auth/service/zms\": dial tcp 127.0.0.1:443: connect: connection refused"
 					want2 := "daemon init error: error when processing pubkey: Error updating ZTS athenz pubkey: error fetch public key entries: error make http request: Get \"https://127.0.0.1/domain/sys.auth/service/zts\": dial tcp 127.0.0.1:443: connect: connection refused"

--- a/service/authorizerd.go
+++ b/service/authorizerd.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package service
 
-import authorizer "github.com/yahoojapan/athenz-authorizer/v2"
+import authorizer "github.com/yahoojapan/athenz-authorizer/v3"
 
 // Authorizationd represents the authorization daemon to do the authorization check.
 type Authorizationd interface {

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -175,7 +175,7 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 	var atOpts []authorizerd.Option
 	if cfg.Authorization.Access.Enable {
 		atOpts = []authorizerd.Option{
-			authorizerd.WithATProcessorParams(
+			authorizerd.WithATProcessorParam(
 				authorizerd.NewATProcessorParam(
 					authzCfg.Access.Enable,
 					authzCfg.Access.VerifyCertThumbprint,

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -164,19 +164,22 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 		authorizerd.WithPolicyRefreshDuration(authzCfg.PolicyRefreshDuration),
 		authorizerd.WithPolicyErrRetryInterval(authzCfg.PolicyErrRetryInterval),
 	}
-	rtOpts := []authorizerd.Option{
-		authorizerd.WithRTVerifyRoleToken(authzCfg.Role.Enable),
-		authorizerd.WithRTHeader(cfg.Proxy.RoleHeader),
+	var rtOpts []authorizerd.Option
+	if authzCfg.Role.Enable {
+		rtOpts = []authorizerd.Option{
+			authorizerd.WithEnableRoleToken(),
+			authorizerd.WithRTHeader(cfg.Proxy.RoleHeader),
+		}
 	}
 	rcOpts := []authorizerd.Option{
-		authorizerd.WithRCVerifyRoleCert(false),
+		authorizerd.WithDisableRoleCert(),
 	}
 
 	var atOpts []authorizerd.Option
 	if cfg.Authorization.Access.Enable {
 		atOpts = []authorizerd.Option{
-			authorizerd.WithATProcessorParam(
-				authorizerd.NewATProcessorParam(
+			authorizerd.WithAccessTokenParam(
+				authorizerd.NewAccessTokenParam(
 					authzCfg.Access.Enable,
 					authzCfg.Access.VerifyCertThumbprint,
 					authzCfg.Access.CertBackdateDur,

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -29,7 +29,7 @@ import (
 	"github.com/yahoojapan/authorization-proxy/router"
 	"github.com/yahoojapan/authorization-proxy/service"
 
-	authorizerd "github.com/yahoojapan/athenz-authorizer/v2"
+	authorizerd "github.com/yahoojapan/athenz-authorizer/v3"
 )
 
 // AuthzProxyDaemon represents Authorization Proxy daemon behavior.

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -172,17 +172,20 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 		authorizerd.WithRCVerifyRoleCert(false),
 	}
 
-	atOpts := []authorizerd.Option{
-		authorizerd.WithATProcessorParams(
-			authorizerd.NewATProcessorParam(
-				authzCfg.Access.Enable,
-				authzCfg.Access.VerifyCertThumbprint,
-				authzCfg.Access.VerifyTokenClientID,
-				authzCfg.Access.AuthorizedPrincipals,
-				authzCfg.Access.CertBackdateDur,
-				authzCfg.Access.CertOffsetDur,
+	var atOpts []authorizerd.Option
+	if cfg.Authorization.Access.Enable {
+		atOpts = []authorizerd.Option{
+			authorizerd.WithATProcessorParams(
+				authorizerd.NewATProcessorParam(
+					authzCfg.Access.Enable,
+					authzCfg.Access.VerifyCertThumbprint,
+					authzCfg.Access.VerifyTokenClientID,
+					authzCfg.Access.AuthorizedPrincipals,
+					authzCfg.Access.CertBackdateDur,
+					authzCfg.Access.CertOffsetDur,
+				),
 			),
-		),
+		}
 	}
 	var jwkOpts []authorizerd.Option
 	if len(atOpts) == 0 {

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -182,7 +182,7 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 					authzCfg.Access.CertBackdateDur,
 					authzCfg.Access.CertOffsetDur,
 					authzCfg.Access.VerifyTokenClientID,
-					authzCfg.Access.AuthorizedPrincipals,
+					authzCfg.Access.AuthorizedClientIDs,
 				),
 			),
 		}

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -179,10 +179,10 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 				authorizerd.NewATProcessorParam(
 					authzCfg.Access.Enable,
 					authzCfg.Access.VerifyCertThumbprint,
-					authzCfg.Access.VerifyTokenClientID,
-					authzCfg.Access.AuthorizedPrincipals,
 					authzCfg.Access.CertBackdateDur,
 					authzCfg.Access.CertOffsetDur,
+					authzCfg.Access.VerifyTokenClientID,
+					authzCfg.Access.AuthorizedPrincipals,
 				),
 			),
 		}

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -173,7 +173,16 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 	}
 
 	atOpts := []authorizerd.Option{
-		authorizerd.WithATProcessorParams(authorizerd.NewATProcessorParam(authzCfg.Access.VerifyCertThumbprint, authzCfg.Access.CertBackdateDur, authzCfg.Access.CertOffsetDur)),
+		authorizerd.WithATProcessorParams(
+			authorizerd.NewATProcessorParam(
+				authzCfg.Access.Enable,
+				authzCfg.Access.VerifyCertThumbprint,
+				authzCfg.Access.VerifyTokenClientID,
+				authzCfg.Access.AuthorizedPrincipals,
+				authzCfg.Access.CertBackdateDur,
+				authzCfg.Access.CertOffsetDur,
+			),
+		),
 	}
 	var jwkOpts []authorizerd.Option
 	if len(atOpts) == 0 {

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -172,11 +172,8 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 		authorizerd.WithRCVerifyRoleCert(false),
 	}
 
-	atOpts := make([]authorizerd.Option, 0, len(authzCfg.Access))
-	for _, atCfg := range authzCfg.Access {
-		if atCfg.Enable {
-			atOpts = append(atOpts, authorizerd.WithATProcessorParams(authorizerd.NewATProcessorParam(atCfg.VerifyCertThumbprint, atCfg.CertBackdateDur, atCfg.CertOffsetDur)))
-		}
+	atOpts := []authorizerd.Option{
+		authorizerd.WithATProcessorParams(authorizerd.NewATProcessorParam(authzCfg.Access.VerifyCertThumbprint, authzCfg.Access.CertBackdateDur, authzCfg.Access.CertOffsetDur)),
 	}
 	var jwkOpts []authorizerd.Option
 	if len(atOpts) == 0 {

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -184,7 +184,7 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 					authzCfg.Access.VerifyCertThumbprint,
 					authzCfg.Access.CertBackdateDur,
 					authzCfg.Access.CertOffsetDur,
-					authzCfg.Access.VerifyTokenClientID,
+					authzCfg.Access.VerifyClientID,
 					authzCfg.Access.AuthorizedClientIDs,
 				),
 			),

--- a/usecase/authz_proxyd_test.go
+++ b/usecase/authz_proxyd_test.go
@@ -677,8 +677,8 @@ func Test_newAuthzD(t *testing.T) {
 						PolicyEtagExpTime:     "10s",
 						PolicyEtagFlushDur:    "10s",
 						Access: config.Access{
-							Enable:              true,
-							VerifyTokenClientID: false,
+							Enable:         true,
+							VerifyClientID: false,
 							AuthorizedClientIDs: map[string][]string{
 								"dummyCN1": {
 									"dummyClientID1",

--- a/usecase/authz_proxyd_test.go
+++ b/usecase/authz_proxyd_test.go
@@ -642,7 +642,7 @@ func Test_newAuthzD(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "test success access token enable/disable",
+			name: "test success access token enable, verify thumbprint disable",
 			args: args{
 				cfg: config.Config{
 					Authorization: config.Authorization{
@@ -658,6 +658,33 @@ func Test_newAuthzD(t *testing.T) {
 							VerifyCertThumbprint: false,
 							CertBackdateDur:      "10s",
 							CertOffsetDur:        "10s",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "test success access token enable, verify client_id disable",
+			args: args{
+				cfg: config.Config{
+					Authorization: config.Authorization{
+						PubKeyRefreshDuration: "10s",
+						PubKeyEtagExpTime:     "10s",
+						PubKeyEtagFlushDur:    "10s",
+						PolicyExpireMargin:    "10s",
+						PolicyRefreshDuration: "10s",
+						PolicyEtagExpTime:     "10s",
+						PolicyEtagFlushDur:    "10s",
+						Access: config.Access{
+							Enable:              true,
+							VerifyTokenClientID: false,
+							AuthorizedPrincipals: map[string][]string{
+								"dummyCN1": {
+									"dummyClientID1",
+									"dummyClientID2",
+								},
+							},
 						},
 					},
 				},

--- a/usecase/authz_proxyd_test.go
+++ b/usecase/authz_proxyd_test.go
@@ -650,16 +650,11 @@ func Test_newAuthzD(t *testing.T) {
 						PolicyRefreshDuration: "10s",
 						PolicyEtagExpTime:     "10s",
 						PolicyEtagFlushDur:    "10s",
-						Access: []config.Access{
-							config.Access{
-								Enable: false,
-							},
-							config.Access{
-								Enable:               true,
-								VerifyCertThumbprint: false,
-								CertBackdateDur:      "10s",
-								CertOffsetDur:        "10s",
-							},
+						Access: config.Access{
+							Enable:               true,
+							VerifyCertThumbprint: false,
+							CertBackdateDur:      "10s",
+							CertOffsetDur:        "10s",
 						},
 					},
 				},

--- a/usecase/authz_proxyd_test.go
+++ b/usecase/authz_proxyd_test.go
@@ -41,6 +41,9 @@ func TestNew(t *testing.T) {
 					PolicyRefreshDuration: "10s",
 					PolicyEtagExpTime:     "10s",
 					PolicyEtagFlushDur:    "10s",
+					Access: config.Access{
+						Enable: true,
+					},
 				},
 				Server: config.Server{
 					HealthzPath: "/dummy",

--- a/usecase/authz_proxyd_test.go
+++ b/usecase/authz_proxyd_test.go
@@ -679,7 +679,7 @@ func Test_newAuthzD(t *testing.T) {
 						Access: config.Access{
 							Enable:              true,
 							VerifyTokenClientID: false,
-							AuthorizedPrincipals: map[string][]string{
+							AuthorizedClientIDs: map[string][]string{
 								"dummyCN1": {
 									"dummyClientID1",
 									"dummyClientID2",


### PR DESCRIPTION
Add the function to check the correspondence between client_id and common name.

This is intended to be used when the certificate bound access token is not available.

todo:
- [x] implement
- [x] implement test
- [x] update go.mod(after mege [this PR](https://github.com/yahoojapan/athenz-authorizer/pull/61))