### PR TITLE
[patch] Remove roletoken enable/disable option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -168,9 +168,6 @@ type Authorization struct {
 
 	// Access represents the configuration to control access token verification.
 	Access Access `yaml:"access_token"`
-
-	// Role represents the configuration to control role token verification.
-	Role Role `yaml:"roletoken"`
 }
 
 // Access represents the access token configuration
@@ -192,12 +189,6 @@ type Access struct {
 
 	// CertOffsetDur represents the certificate issue time offset duration when comparing with the issue time of the access token. (for usecase: new cert + old token)
 	CertOffsetDur string `yaml:"cert_offset_dur"`
-}
-
-// Role represents the role token configuration
-type Role struct {
-	// Enable decides whether to verify role token
-	Enable bool `yaml:"enable"`
 }
 
 // DebugServer represents the server for debug use.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -123,9 +123,6 @@ func TestNew(t *testing.T) {
 					PolicyRefreshDuration: "1h",
 					PolicyEtagExpTime:     "48h",
 					PolicyEtagFlushDur:    "24h",
-					Role: Role{
-						Enable: true,
-					},
 					Access: Access{
 						Enable:               true,
 						VerifyCertThumbprint: true,

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -39,8 +39,6 @@ provider:
   policyRefreshDuration: 1h
   policyEtagExpTime: 48h
   policyEtagFlushDur: 24h
-  roletoken:
-      enable: true
   access_token:
     enable: true
     verify_cert_thumbprint: true

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -168,11 +168,6 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 		authorizerd.WithEnableRoleToken(),
 		authorizerd.WithRTHeader(cfg.Proxy.RoleHeader),
 	}
-	if !authzCfg.Role.Enable {
-		rtOpts = []authorizerd.Option{
-			authorizerd.WithDisableRoleToken(),
-		}
-	}
 	rcOpts := []authorizerd.Option{
 		authorizerd.WithDisableRoleCert(),
 	}

--- a/usecase/authz_proxyd_test.go
+++ b/usecase/authz_proxyd_test.go
@@ -633,9 +633,6 @@ func Test_newAuthzD(t *testing.T) {
 						PolicyRefreshDuration: "10s",
 						PolicyEtagExpTime:     "10s",
 						PolicyEtagFlushDur:    "10s",
-						Role: config.Role{
-							Enable: true,
-						},
 					},
 				},
 			},


### PR DESCRIPTION
Removed the roletoken option for backward compatibility.

This pattern was used to check the operation. 
In both patterns, the roletoken function worked.
```
$ grep -A 1 ${config_path}
  roletoken:
    enable: false

$ grep -A 1 ${config_path}
  #roletoken:
  #  enable: false
```

