### PR TITLE
[major] Add jwk urls

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -212,6 +212,9 @@ type JWK struct {
 
 	// RetryDelay represents the duration between each retry.
 	RetryDelay string `yaml:"retryDelay"`
+
+	// URLs represents URLs that delivers JWK Set excluding athenz.
+	URLs []string `yaml:"urls"`
 }
 
 // AccessToken represents the configuration to control access token verification.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -131,7 +131,7 @@ func TestNew(t *testing.T) {
 					JWK: JWK{
 						RefreshPeriod: "",
 						RetryDelay:    "",
-						URLs:          []string{"https://jwk.athenz.io:4443/path/to/key"},
+						URLs:          []string{"http://your-jwk-set-url1", "https://your-jwk-set-url2"},
 					},
 					AccessToken: AccessToken{
 						Enable:               true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -131,6 +131,7 @@ func TestNew(t *testing.T) {
 					JWK: JWK{
 						RefreshPeriod: "",
 						RetryDelay:    "",
+						URLs:          []string{"https://jwk.athenz.io:4443/path/to/key"},
 					},
 					AccessToken: AccessToken{
 						Enable:               true,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/kpango/glg v1.5.1
 	github.com/pkg/errors v0.9.1
-	github.com/yahoojapan/athenz-authorizer/v4 v4.1.2
+	github.com/yahoojapan/athenz-authorizer/v5 v5.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -61,12 +61,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/yahoo/athenz v1.9.10 h1:knKGFb/8FxPW1ZnlVNq/b4mPRj0WFTFk6DVNKS8gtLI=
 github.com/yahoo/athenz v1.9.10/go.mod h1:LyE/c1Pe3bEsMB/ZavwGOH+D3MIS6GS7fLtdEbzJfaI=
-github.com/yahoojapan/athenz-authorizer/v4 v4.0.1 h1:t3lsXOC2Y05/lVjQHq34xacGhV60UZKTundPq/SSy5M=
-github.com/yahoojapan/athenz-authorizer/v4 v4.0.1/go.mod h1:Zf2aL9WwNpyWBBdPajIjRsfmqIB4fBO29kQLwx/pnjo=
-github.com/yahoojapan/athenz-authorizer/v4 v4.1.0 h1:c3vlnDnEkGOuSPt99HIW4JKjDp1ejLOFj7iiNDhNFb4=
-github.com/yahoojapan/athenz-authorizer/v4 v4.1.0/go.mod h1:Zf2aL9WwNpyWBBdPajIjRsfmqIB4fBO29kQLwx/pnjo=
-github.com/yahoojapan/athenz-authorizer/v4 v4.1.2 h1:w1fddJy6ruJ0HWGtTxuJOfHOR5jsKIC5Zyy9F//t8lg=
-github.com/yahoojapan/athenz-authorizer/v4 v4.1.2/go.mod h1:Zf2aL9WwNpyWBBdPajIjRsfmqIB4fBO29kQLwx/pnjo=
+github.com/yahoojapan/athenz-authorizer/v5 v5.0.1 h1:NJmeivXm4q7ZdSNJc+67Xl7A+sUQXUmqVJstwVD8D4g=
+github.com/yahoojapan/athenz-authorizer/v5 v5.0.1/go.mod h1:vS09DjPxY8Ju8BYBJV8MDC+OxXnIYpj/r8jKHpNZF+4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zeebo/xxh3 v0.0.0-20191227220208-65f423c10688 h1:C5YYdD+oJh6KoLMePMeA/+PPy2vgsEb6UBBMIy4ug+s=
 github.com/zeebo/xxh3 v0.0.0-20191227220208-65f423c10688/go.mod h1:e/zZObEJWtkq6f+bAzme0xQJSGI75oxoeqS+f2I7YVI=

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -5,12 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
-	authorizerd "github.com/yahoojapan/athenz-authorizer/v4"
-	"github.com/yahoojapan/athenz-authorizer/v4/role"
-	"github.com/yahoojapan/authorization-proxy/v3/config"
-	"github.com/yahoojapan/authorization-proxy/v3/infra"
-	"github.com/yahoojapan/authorization-proxy/v3/service"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -19,6 +13,13 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
+	authorizerd "github.com/yahoojapan/athenz-authorizer/v5"
+	"github.com/yahoojapan/athenz-authorizer/v5/role"
+	"github.com/yahoojapan/authorization-proxy/v3/config"
+	"github.com/yahoojapan/authorization-proxy/v3/infra"
+	"github.com/yahoojapan/authorization-proxy/v3/service"
 )
 
 func TestNew(t *testing.T) {

--- a/handler/transport.go
+++ b/handler/transport.go
@@ -17,10 +17,11 @@ limitations under the License.
 package handler
 
 import (
-	authorizerd "github.com/yahoojapan/athenz-authorizer/v4"
 	"net/http"
 	"strconv"
 	"strings"
+
+	authorizerd "github.com/yahoojapan/athenz-authorizer/v5"
 
 	"github.com/yahoojapan/authorization-proxy/v3/config"
 	"github.com/yahoojapan/authorization-proxy/v3/service"

--- a/handler/transport_test.go
+++ b/handler/transport_test.go
@@ -2,10 +2,11 @@ package handler
 
 import (
 	"errors"
-	authorizerd "github.com/yahoojapan/athenz-authorizer/v4"
 	"net/http"
 	"reflect"
 	"testing"
+
+	authorizerd "github.com/yahoojapan/athenz-authorizer/v5"
 
 	"github.com/yahoojapan/authorization-proxy/v3/config"
 	"github.com/yahoojapan/authorization-proxy/v3/service"

--- a/service/authorizerd.go
+++ b/service/authorizerd.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package service
 
-import authorizer "github.com/yahoojapan/athenz-authorizer/v4"
+import authorizer "github.com/yahoojapan/athenz-authorizer/v5"
 
 // Authorizationd represents the authorization daemon to do the authorization check.
 type Authorizationd interface {

--- a/service/authorizerd_mock.go
+++ b/service/authorizerd_mock.go
@@ -3,8 +3,9 @@ package service
 import (
 	"context"
 	"crypto/x509"
-	authorizerd "github.com/yahoojapan/athenz-authorizer/v4"
 	"net/http"
+
+	authorizerd "github.com/yahoojapan/athenz-authorizer/v5"
 )
 
 // AuthorizerdMock is a mock of Authorizerd

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -50,7 +50,8 @@ authorization:
     refreshPeriod: ""
     retryDelay: ""
     urls:
-      - https://jwk.athenz.io:4443/path/to/key
+      - http://your-jwk-set-url1
+      - https://your-jwk-set-url2
   accessToken:
     enable: true
     verifyCertThumbprint: true

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -49,6 +49,8 @@ authorization:
   jwk:
     refreshPeriod: ""
     retryDelay: ""
+    urls:
+      - https://jwk.athenz.io:4443/path/to/key
   accessToken:
     enable: true
     verifyCertThumbprint: true

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -32,7 +32,7 @@ import (
 	"github.com/yahoojapan/authorization-proxy/v3/router"
 	"github.com/yahoojapan/authorization-proxy/v3/service"
 
-	authorizerd "github.com/yahoojapan/athenz-authorizer/v4"
+	authorizerd "github.com/yahoojapan/athenz-authorizer/v5"
 )
 
 // AuthzProxyDaemon represents Authorization Proxy daemon behavior.

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -232,6 +232,7 @@ func newAuthzD(cfg config.Config) (service.Authorizationd, error) {
 			// use value in config.go in later version
 			authorizerd.WithJwkRefreshPeriod(authzCfg.JWK.RefreshPeriod),
 			authorizerd.WithJwkRetryDelay(authzCfg.JWK.RetryDelay),
+			authorizerd.WithJwkURLs(authzCfg.JWK.URLs),
 		}
 	} else {
 		atOpts = []authorizerd.Option{

--- a/usecase/authz_proxyd_test.go
+++ b/usecase/authz_proxyd_test.go
@@ -661,6 +661,9 @@ func Test_newAuthzD(t *testing.T) {
 							CertOffsetDuration:   "10s",
 						},
 					},
+					Athenz: config.Athenz{
+						URL: "dummy-athenz-url",
+					},
 				},
 			},
 			want: true,
@@ -690,6 +693,9 @@ func Test_newAuthzD(t *testing.T) {
 								},
 							},
 						},
+					},
+					Athenz: config.Athenz{
+						URL: "dummy-athenz-url",
 					},
 				},
 			},


### PR DESCRIPTION
# Description
The purpose of this PR is to follow up on this [PR](https://github.com/yahoojapan/athenz-authorizer/pull/77).
The access token with the jku header can be verified using the JWK Set specified in jwk.urls.
 
TODO:
- [ ] merge https://github.com/yahoojapan/athenz-authorizer/pull/77
- [ ] Update go.mod
## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] breaks backward compatibility
- [ ] requires a documentation update
- [ ] has untestable code

## Related issue/PR
- https://github.com/yahoojapan/athenz-authorizer/pull/77

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[major]`/`[minor]`/`[patch]`/`[skip]` in the PR title
- [x] Tested and linted the code
- [x] Commented the code
- [ ] Made corresponding changes to the documentation
- [x] Confirmed no dropping in test coverage (by [Codecov](https://codecov.io/gh/yahoojapan/authorization-proxy/pulls))
- [x] Passed all pipeline checking
- [x] Approved by >1 reviewer

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[major]`/`[minor]`/`[patch]`/`[skip]`
- [ ] Delete the branch after merge
