### PR TITLE
[minor] new config option for customizing host header

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,6 +147,9 @@ type Proxy struct {
 	// Tips for performance: define your health check endpoint with a different length from the most frequently used endpoint, for example, use `/healthcheck` (len: 12) when `/most_used` (len: 10), instead of `/healthccc` (len: 10)
 	OriginHealthCheckPaths []string `yaml:"originHealthCheckPaths"`
 
+	// Request exposes http.Request parameters
+	Request Request `yaml:"request,omitempty"`
+
 	// Transport exposes http.Transport parameters
 	Transport Transport `yaml:"transport,omitempty"`
 }
@@ -263,6 +266,11 @@ type Log struct {
 
 	// Color represents whether to print ANSI escape code.
 	Color bool `yaml:"color"`
+}
+
+// Request exposes a subset of Request parameters. reference: https://github.com/golang/go/blob/master/src/net/http/request.go#L103
+type Request struct {
+	Host string `yaml:"host,omitempty"`
 }
 
 // Transport exposes a subset of Transport parameters. reference: https://github.com/golang/go/blob/master/src/net/http/transport.go#L95

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,6 +112,9 @@ func TestNew(t *testing.T) {
 					Port:                   80,
 					BufferSize:             4096,
 					OriginHealthCheckPaths: []string{},
+					Request: Request{
+						Host: "remote.host",
+					},
 					Transport: Transport{
 						TLSHandshakeTimeout:    10 * time.Second,
 						DisableKeepAlives:      false,

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -61,6 +61,7 @@ func New(cfg config.Proxy, bp httputil.BufferPool, prov service.Authorizationd) 
 			req.TLS = r.TLS
 			if cfg.Request.Host != "" {
 				req.Host = cfg.Request.Host
+				glg.Debugf("set request host from config: %s\n", req.Host)
 			}
 
 			*r = *req

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -59,6 +59,10 @@ func New(cfg config.Proxy, bp httputil.BufferPool, prov service.Authorizationd) 
 			}
 			req.Header = r.Header
 			req.TLS = r.TLS
+			if cfg.Request.Host != "" {
+				req.Host = cfg.Request.Host
+			}
+
 			*r = *req
 		},
 		Transport: &transport{

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -29,6 +29,8 @@ proxy:
   port: 80
   bufferSize: 4096
   originHealthCheckPaths: []
+  request:
+    host: "remote.host"
   transport:
     tlsHandshakeTimeout: "10s"
     disableKeepAlives: false


### PR DESCRIPTION
# Description

## changes

- new config option for customizing host header

### old config (default config)

- proxy config
    ```yaml
    proxy:
      host: localhost
      port: 8087
    ```
- proxied request
    ```log
    Request Headers:
        host=localhost:8087
    ```

### new config

- proxy config
    ```yaml
    proxy:
      host: localhost
      port: 8087
      request:
        host: "dummy.remote.host"
    ```
- proxied request
    ```log
    Request Headers:
        host=dummy.remote.host
    ```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] breaks backward compatibility
- [ ] requires a documentation update
- [ ] has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[major]`/`[minor]`/`[patch]`/`[skip]` in the PR title
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Confirmed no dropping in test coverage (by [Codecov](https://codecov.io/gh/yahoojapan/authorization-proxy/pulls))
- [x] Passed all pipeline checking
- [ ] Approved by >1 reviewer

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[major]`/`[minor]`/`[patch]`/`[skip]`
- [ ] Delete the branch after merge
