### PR TITLE
[minor] proxy preserve host

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,6 +147,9 @@ type Proxy struct {
 	// Tips for performance: define your health check endpoint with a different length from the most frequently used endpoint, for example, use `/healthcheck` (len: 12) when `/most_used` (len: 10), instead of `/healthccc` (len: 10)
 	OriginHealthCheckPaths []string `yaml:"originHealthCheckPaths"`
 
+	// Request exposes http.Request parameters
+	Request Request `yaml:"request,omitempty"`
+
 	// Transport exposes http.Transport parameters
 	Transport Transport `yaml:"transport,omitempty"`
 }
@@ -263,6 +266,11 @@ type Log struct {
 
 	// Color represents whether to print ANSI escape code.
 	Color bool `yaml:"color"`
+}
+
+// Request exposes a subset of Request parameters. reference: https://github.com/golang/go/blob/master/src/net/http/request.go#L103
+type Request struct {
+	Host string `yaml:"host,omitempty"`
 }
 
 // Transport exposes a subset of Transport parameters. reference: https://github.com/golang/go/blob/master/src/net/http/transport.go#L95

--- a/config/config.go
+++ b/config/config.go
@@ -147,8 +147,8 @@ type Proxy struct {
 	// Tips for performance: define your health check endpoint with a different length from the most frequently used endpoint, for example, use `/healthcheck` (len: 12) when `/most_used` (len: 10), instead of `/healthccc` (len: 10)
 	OriginHealthCheckPaths []string `yaml:"originHealthCheckPaths"`
 
-	// Request exposes http.Request parameters
-	Request Request `yaml:"request,omitempty"`
+	// PreserveHost represents whether to preserve the host header from the request.
+	PreserveHost bool `yaml:"preserveHost"`
 
 	// Transport exposes http.Transport parameters
 	Transport Transport `yaml:"transport,omitempty"`
@@ -266,11 +266,6 @@ type Log struct {
 
 	// Color represents whether to print ANSI escape code.
 	Color bool `yaml:"color"`
-}
-
-// Request exposes a subset of Request parameters. reference: https://github.com/golang/go/blob/master/src/net/http/request.go#L103
-type Request struct {
-	Host string `yaml:"host,omitempty"`
 }
 
 // Transport exposes a subset of Transport parameters. reference: https://github.com/golang/go/blob/master/src/net/http/transport.go#L95

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,9 +112,7 @@ func TestNew(t *testing.T) {
 					Port:                   80,
 					BufferSize:             4096,
 					OriginHealthCheckPaths: []string{},
-					Request: Request{
-						Host: "remote.host",
-					},
+					PreserveHost:           true,
 					Transport: Transport{
 						TLSHandshakeTimeout:    10 * time.Second,
 						DisableKeepAlives:      false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,6 +112,9 @@ func TestNew(t *testing.T) {
 					Port:                   80,
 					BufferSize:             4096,
 					OriginHealthCheckPaths: []string{},
+					Request: Request{
+						Host: "remote.host",
+					},
 					Transport: Transport{
 						TLSHandshakeTimeout:    10 * time.Second,
 						DisableKeepAlives:      false,

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -61,6 +61,7 @@ func New(cfg config.Proxy, bp httputil.BufferPool, prov service.Authorizationd) 
 			req.TLS = r.TLS
 			if cfg.Request.Host != "" {
 				req.Host = cfg.Request.Host
+				glg.Debugf("set request host from config: %s\n", req.Host)
 			}
 
 			*r = *req

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -59,6 +59,10 @@ func New(cfg config.Proxy, bp httputil.BufferPool, prov service.Authorizationd) 
 			}
 			req.Header = r.Header
 			req.TLS = r.TLS
+			if cfg.Request.Host != "" {
+				req.Host = cfg.Request.Host
+			}
+
 			*r = *req
 		},
 		Transport: &transport{

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -59,9 +59,9 @@ func New(cfg config.Proxy, bp httputil.BufferPool, prov service.Authorizationd) 
 			}
 			req.Header = r.Header
 			req.TLS = r.TLS
-			if cfg.Request.Host != "" {
-				req.Host = cfg.Request.Host
-				glg.Debugf("set request host from config: %s\n", req.Host)
+			if cfg.PreserveHost {
+				req.Host = r.Host
+				glg.Debugf("proxy.PreserveHost enabled, forward host header: %s\n", req.Host)
 			}
 
 			*r = *req

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -437,7 +437,7 @@ func TestNew(t *testing.T) {
 		func() test {
 			handler := http.HandlerFunc(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// check host header
-				if r.Host != "remote.host.460" {
+				if r.Host != "remote.host.469" {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
@@ -446,7 +446,7 @@ func TestNew(t *testing.T) {
 			srv := httptest.NewServer(handler)
 
 			return test{
-				name: "check custom host header is used",
+				name: "check preserve host",
 				args: args{
 					cfg: config.Proxy{
 						Host: strings.Split(strings.Replace(srv.URL, "http://", "", 1), ":")[0],
@@ -454,9 +454,7 @@ func TestNew(t *testing.T) {
 							a, _ := strconv.ParseInt(strings.Split(srv.URL, ":")[2], 0, 64)
 							return uint16(a)
 						}(),
-						Request: config.Request{
-							Host: "remote.host.460",
-						},
+						PreserveHost: true,
 					},
 					bp: infra.NewBuffer(64),
 					prov: &service.AuthorizerdMock{
@@ -468,6 +466,7 @@ func TestNew(t *testing.T) {
 				checkFunc: func(h http.Handler) error {
 					rw := httptest.NewRecorder()
 					r := httptest.NewRequest("GET", "http://dummy.com", nil)
+					r.Host = "remote.host.469"
 					h.ServeHTTP(rw, r)
 					if rw.Code != http.StatusOK {
 						return errors.Errorf("unexpected status code (invalid host header), got: %v, want: %v", rw.Code, http.StatusOK)

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -29,8 +29,7 @@ proxy:
   port: 80
   bufferSize: 4096
   originHealthCheckPaths: []
-  request:
-    host: "remote.host"
+  preserveHost: true
   transport:
     tlsHandshakeTimeout: "10s"
     disableKeepAlives: false

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -29,6 +29,8 @@ proxy:
   port: 80
   bufferSize: 4096
   originHealthCheckPaths: []
+  request:
+    host: "remote.host"
   transport:
     tlsHandshakeTimeout: "10s"
     disableKeepAlives: false


### PR DESCRIPTION
# Description


## changes

- allow preserve host header from request (forward to origin)

### old config (default config)

- proxy config
    ```yaml
    proxy:
      host: localhost
      port: 8087
    ```
- proxied request
    ```log
    Request Headers:
        host=localhost:8087
    ```

### new config

- proxy config
    ```yaml
    proxy:
      host: localhost
      port: 8087
      preserveHost: true
    ```
- proxied request (`Host: `)
    ```log
    Request Headers:
        host=localhost:8087 #<cfg.proxy.Host:cfg.proxy.port>
    ```
- proxied request (`Host: dummy.remote.host`)
    ```log
    Request Headers:
        host=dummy.remote.host #<request.Host>
    ```


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] breaks backward compatibility
- [ ] requires a documentation update
- [ ] has untestable code

## Related issue/PR

- Closes #89

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[major]`/`[minor]`/`[patch]`/`[skip]` in the PR title
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Confirmed no dropping in test coverage (by [Codecov](https://codecov.io/gh/yahoojapan/authorization-proxy/pulls))
- [x] Passed all pipeline checking
- [ ] Approved by >1 reviewer

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[major]`/`[minor]`/`[patch]`/`[skip]`
- [ ] Delete the branch after merge
